### PR TITLE
Add Xquik MCP entry and fix README drift checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A **maintainable** curated list of Model Context Protocol (MCP) servers, clients
 
 Unlike a hand-edited markdown wall, this repo stores entries in [`data/catalog.yaml`](data/catalog.yaml) and ships tooling to **search**, **validate**, and **serve** the catalog as an MCP meta-server.
 
-- **27** curated entries
-- **13** servers · **6** clients · **4** registries · **4** SDKs/tools
+- **28** curated entries
+- **14** servers · **6** clients · **4** registries · **4** SDKs/tools
 - **16** official / reference projects
 - Catalog updated: `2026-06-18`
 
@@ -86,6 +86,10 @@ This repo includes a small MCP server that exposes the catalog to agents:
 ### Productivity
 
 - [Google Drive Server](https://github.com/modelcontextprotocol/servers/tree/main/src/gdrive) ✅ `stdio` — List, read, and search files in Google Drive. — `google`, `files`
+
+### Social
+
+- [Xquik MCP](https://docs.xquik.com/mcp/overview) `remote` — Remote X data MCP server for search, profiles, timelines, monitoring, webhooks, and confirmation-gated writes. Not affiliated with X Corp. — `x`, `twitter`, `social`, `api`
 
 ### Web
 

--- a/data/catalog.yaml
+++ b/data/catalog.yaml
@@ -109,6 +109,16 @@ entries:
     official: false
     tags: [search, api]
 
+  - id: xquik
+    name: Xquik MCP
+    kind: server
+    category: social
+    url: https://docs.xquik.com/mcp/overview
+    description: Remote X data MCP server for search, profiles, timelines, monitoring, webhooks, and confirmation-gated writes. Not affiliated with X Corp.
+    transport: [remote]
+    official: false
+    tags: [x, twitter, social, api]
+
   - id: google-drive
     name: Google Drive Server
     kind: server

--- a/src/awesome_mcp/cli.py
+++ b/src/awesome_mcp/cli.py
@@ -9,10 +9,12 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
-from .catalog import Kind, get_catalog, load_catalog
-from .readme import write_readme
+from .catalog import Kind, load_catalog
+from .readme import render_readme, write_readme
 
-app = typer.Typer(add_completion=False, no_args_is_help=True, help="Browse and maintain the Awesome-MCP catalog.")
+app = typer.Typer(
+    add_completion=False, no_args_is_help=True, help="Browse and maintain the Awesome-MCP catalog."
+)
 console = Console()
 
 
@@ -72,7 +74,7 @@ def search(
         raise typer.Exit(code=1)
     for entry in hits:
         official = " [green]official[/green]" if entry.official else ""
-        console.print(f"[bold]{entry.name}[/bold] ({entry.id}) — {entry.kind}{official}")
+        console.print(f"[bold]{entry.name}[/bold] ({entry.id}) - {entry.kind}{official}")
         console.print(f"  {entry.description}")
         console.print(f"  [link={entry.url}]{entry.url}[/link]")
         if entry.tags:
@@ -103,14 +105,16 @@ def generate_readme(
     """Generate README.md from catalog.yaml."""
     catalog = load_catalog(catalog_path)
     target = output or Path("README.md")
-    rendered = write_readme(target, catalog)
     if check:
-        expected = (Path(__file__).resolve().parents[2] / "README.md").read_text(encoding="utf-8")
-        actual = target.read_text(encoding="utf-8")
-        if expected != actual and output is None:
+        expected = render_readme(catalog)
+        actual = target.read_text(encoding="utf-8") if target.is_file() else None
+        if actual != expected:
             console.print("[red]README.md is out of date. Run: awesome-mcp readme[/red]")
             raise typer.Exit(code=1)
-    console.print(f"Wrote [bold]{rendered}[/bold]")
+        console.print(f"[green]README.md is current:[/green] {target}")
+        return
+    written_path = write_readme(target, catalog)
+    console.print(f"Wrote [bold]{written_path}[/bold]")
 
 
 @app.command("validate")
@@ -126,7 +130,7 @@ def validate(catalog_path: Optional[Path] = typer.Option(None, "--catalog")) -> 
         if not entry.url.startswith("http"):
             console.print(f"[red]Invalid url for {entry.id}:[/red] {entry.url}")
             raise typer.Exit(code=1)
-    console.print(f"[green]OK[/green] — {len(catalog.entries)} entries validated")
+    console.print(f"[green]OK[/green] - {len(catalog.entries)} entries validated")
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,84 @@
+"""Tests for the Awesome-MCP command-line interface."""
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from awesome_mcp.cli import app
+
+
+def test_readme_check_detects_drift_without_rewriting(tmp_path: Path) -> None:
+    project_root = Path(__file__).resolve().parents[1]
+    readme_path = tmp_path / "README.md"
+    stale_content = "stale readme\n"
+    readme_path.write_text(stale_content, encoding="utf-8")
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "readme",
+            "--catalog",
+            str(project_root / "data" / "catalog.yaml"),
+            "--output",
+            str(readme_path),
+            "--check",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "README.md is out of date" in result.stdout
+    assert readme_path.read_text(encoding="utf-8") == stale_content
+
+
+def test_readme_check_does_not_create_missing_output(tmp_path: Path) -> None:
+    project_root = Path(__file__).resolve().parents[1]
+    readme_path = tmp_path / "missing.md"
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "readme",
+            "--catalog",
+            str(project_root / "data" / "catalog.yaml"),
+            "--output",
+            str(readme_path),
+            "--check",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "README.md is out of date" in result.stdout
+    assert not readme_path.exists()
+
+
+def test_readme_check_accepts_current_custom_output(tmp_path: Path) -> None:
+    project_root = Path(__file__).resolve().parents[1]
+    readme_path = tmp_path / "README.md"
+    generate_result = CliRunner().invoke(
+        app,
+        [
+            "readme",
+            "--catalog",
+            str(project_root / "data" / "catalog.yaml"),
+            "--output",
+            str(readme_path),
+        ],
+    )
+    current_content = readme_path.read_text(encoding="utf-8")
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "readme",
+            "--catalog",
+            str(project_root / "data" / "catalog.yaml"),
+            "--output",
+            str(readme_path),
+            "--check",
+        ],
+    )
+
+    assert generate_result.exit_code == 0
+    assert result.exit_code == 0
+    assert "README.md is current" in result.stdout
+    assert readme_path.read_text(encoding="utf-8") == current_content


### PR DESCRIPTION
Summary
- Add Xquik MCP as a remote social data server in data/catalog.yaml.
- Regenerate README.md from the catalogue with current auth and write semantics.
- Make awesome-mcp readme --check compare rendered content without rewriting the target.
- Cover stale, missing, and current custom outputs with regression tests.

Independent repository fix
The previous check mode wrote the README before comparing it. Default checks therefore compared the rewritten file with itself, custom output checks skipped mismatches, and check mode unexpectedly mutated files. The command now renders in memory, reports missing or stale targets, and writes nothing in check mode.

Validation
- pytest -q: 6 passed
- ruff check .
- awesome-mcp validate: 28 entries validated
- awesome-mcp readme --check
- python -m compileall -q src tests
- uv pip check
- Xquik documentation: HTTP 200
- Clean diff against current upstream main

AI assistance
Prepared and verified with Codex.

Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
