### PR TITLE
feat: add NotFair — SEO & paid-ads MCP server bundle

### DIFF
--- a/data/catalog.yaml
+++ b/data/catalog.yaml
@@ -149,6 +149,16 @@ entries:
     official: true
     tags: [reasoning, planning]
 
+  - id: notfair
+    name: NotFair
+    kind: server
+    category: marketing
+    url: https://github.com/nowork-studio/NotFair
+    description: Open-source Claude Code skills for SEO, GEO, and paid ads — connects to Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP for live account data.
+    transport: [stdio]
+    official: false
+    tags: [seo, google-ads, meta-ads, marketing, claude-code]
+
   - id: cursor
     name: Cursor
     kind: client


### PR DESCRIPTION
Thanks for maintaining this catalog — it's a clean and well-structured resource.

I'd like to add **[NotFair](https://github.com/nowork-studio/NotFair)**, an open-source set of Claude Code agent skills for SEO and paid advertising work. It connects to live account data through the **Google Ads MCP**, **Meta Ads MCP**, **Google Search Console MCP**, and **Google Analytics (GA4) MCP**, which is why it feels at home in an MCP catalog. The project has ~2.9k stars and is MIT-licensed.

I've added it to `data/catalog.yaml` under `kind: server` with `category: marketing`, following the entry schema in CONTRIBUTING.md. Happy to adjust the category, description, or tags if something fits better.

Let me know if you'd like any changes — thanks again!