### PR TITLE
Add ax MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A **maintainable** curated list of Model Context Protocol (MCP) servers, clients
 
 Unlike a hand-edited markdown wall, this repo stores entries in [`data/catalog.yaml`](data/catalog.yaml) and ships tooling to **search**, **validate**, and **serve** the catalog as an MCP meta-server.
 
-- **27** curated entries
-- **13** servers · **6** clients · **4** registries · **4** SDKs/tools
+- **28** curated entries
+- **14** servers · **6** clients · **4** registries · **4** SDKs/tools
 - **16** official / reference projects
 - Catalog updated: `2026-06-18`
 
@@ -79,6 +79,7 @@ This repo includes a small MCP server that exposes the catalog to agents:
 
 ### Developer Tools
 
+- [ax](https://github.com/Necmttn/ax) `stdio` — Local-first telemetry and memory graph for AI coding agents. — `coding`, `telemetry`, `local-first`
 - [Filesystem Server](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem) ✅ `stdio` — Secure local file read/write with configurable directory allowlists. — `files`, `local`
 - [GitHub MCP Server](https://github.com/github/github-mcp-server) ✅ `stdio, remote` — Official GitHub integration for repos, issues, PRs, and Actions. — `github`, `git`
 - [Official MCP Reference Servers](https://github.com/modelcontextprotocol/servers) ✅ `stdio` — Reference implementations maintained by the MCP steering group (filesystem, memory, fetch, git, and more). — `reference`, `anthropic`

--- a/data/catalog.yaml
+++ b/data/catalog.yaml
@@ -69,6 +69,16 @@ entries:
     official: true
     tags: [github, git]
 
+  - id: ax
+    name: ax
+    kind: server
+    category: developer-tools
+    url: https://github.com/Necmttn/ax
+    description: Local-first telemetry and memory graph for AI coding agents.
+    transport: [stdio]
+    official: false
+    tags: [coding, telemetry, local-first]
+
   - id: playwright-mcp
     name: Playwright MCP
     kind: server


### PR DESCRIPTION
Adds ax to the Developer Tools MCP server category.

ax fits this catalog because it exposes read-only MCP queries over a local telemetry and memory graph for AI coding agents, including sessions, tools, skills, costs, and workflow evidence.

---

_Generated with [ax](https://github.com/Necmttn/ax)._