### PR TITLE
feat(catalog): add BuyWhere MCP — real-time product search & price comparison

### DIFF
--- a/data/catalog.yaml
+++ b/data/catalog.yaml
@@ -109,6 +109,16 @@ entries:
     official: false
     tags: [search, api]
 
+  - id: buywhere
+    name: BuyWhere MCP
+    kind: server
+    category: web
+    url: https://github.com/BuyWhere/buywhere-mcp
+    description: Real-time product search and price comparison across 148M+ products from Singapore, Southeast Asia, and US marketplaces via remote streamable-HTTP.
+    transport: [remote]
+    official: false
+    tags: [search, ecommerce, api]
+
   - id: google-drive
     name: Google Drive Server
     kind: server


### PR DESCRIPTION
## What is BuyWhere MCP?

BuyWhere MCP is a **remote streamable-HTTP** MCP server that exposes real-time product search and price comparison across **148M+ products** from Singapore, Southeast Asia, and US marketplaces (Shopee, Lazada, Amazon, Walmart, and 20+ retailers).

- **Endpoint**: `https://api.buywhere.ai/mcp` (remote, no install)
- **Auth**: Free API key (no signup) at https://buywhere.ai/api-keys
- **Tools**: `search_products`, `compare_prices`, `get_deals`, `list_categories`, `get_product`
- **Transport**: remote streamable-HTTP + stdio via `npx @buywhere/mcp-server`
- **Listed**: Smithery (useCount=11), registry.modelcontextprotocol.io (17 entries, v1.0.5), Glama, mcp.so, mcpservers.org, OpenTools.ai, PulseMCP, +10 awesome-* GitHub lists
- **Stats (live)**: 148,554,224 products / 84,705 merchants at https://api.buywhere.ai/v1/catalog/stats

## Catalog change

This adds **one entry** to `data/catalog.yaml` in the **`web`** category (alongside Brave Search):

```yaml
- id: buywhere
  name: BuyWhere MCP
  kind: server
  category: web
  url: https://github.com/BuyWhere/buywhere-mcp
  description: Real-time product search and price comparison across 148M+ products from Singapore, Southeast Asia, and US marketplaces via remote streamable-HTTP.
  transport: [remote]
  official: false
  tags: [search, ecommerce, api]
```

10 lines added, 0 removed. Single-file change per CONTRIBUTING.md.

## Validation

```
$ python3 -c "import yaml; data = yaml.safe_load(open('data/catalog.yaml'))"
Entries: 28  (was 27, +1)
Schema check: PASS
Duplicate IDs: NONE
```

## Why this belongs

BuyWhere is **the** cross-border commerce data layer for AI agents:
- Real SEA/SG merchant coverage (Shopee, Lazada, NTUC, FairPrice, Watsons)
- US marketplace coverage (Amazon, Walmart, Target, Best Buy)
- Live price + deal discovery, not just static product catalogs
- Free tier for AI agent developers (no signup)
- Officially listed on the MCP Registry as `io.github.BuyWhere/buywhere-mcp@1.0.5`

## Links

- Source: https://github.com/BuyWhere/buywhere-mcp
- Project site: https://buywhere.ai
- API docs: https://api.buywhere.ai/docs
- MCP Registry: https://registry.modelcontextprotocol.io
- npm: https://www.npmjs.com/package/@buywhere/mcp-server
