### PR TITLE
Add MyMCPTools to Registries & Directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Legend: ✅ = Official / reference project · Transport: `stdio`/`sse`/`remote`
 - [Glama MCP Directory](https://glama.ai/mcp/servers) `remote` — MCP server directory with quality scores and hosted deployment options. — `directory`, `hosting`
 - [MCP Registry (Official)](https://registry.modelcontextprotocol.io) ✅ `remote` — Official MCP server registry and specification hub. — `official`, `spec`
 - [MCP.so](https://mcp.so) `remote` — Community-driven searchable directory of MCP servers. — `directory`, `community`
+- [MyMCPTools](https://mymcptools.com) `remote` — Directory of MCP servers with scheduled live handshakes — each entry carries an install-time reachability verdict and latency. — `directory`, `uptime`
 - [Smithery](https://smithery.ai) `remote` — Curated MCP registry with one-click install flows for popular clients. — `directory`, `install`
 
 <!-- CATALOG:REGISTRIES:END -->

--- a/data/catalog.yaml
+++ b/data/catalog.yaml
@@ -279,6 +279,16 @@ entries:
     official: false
     tags: [directory, community]
 
+  - id: mymcptools
+    name: MyMCPTools
+    kind: registry
+    category: directory
+    url: https://mymcptools.com
+    description: Directory of MCP servers with scheduled live handshakes — each entry carries an install-time reachability verdict and latency.
+    transport: [remote]
+    official: false
+    tags: [directory, uptime]
+
   - id: glama
     name: Glama MCP Directory
     kind: registry


### PR DESCRIPTION
Adds one `kind: registry` / `category: directory` record to `data/catalog.yaml`, alongside Glama, MCP.so, Smithery and the official registry.

**Why it earns a place next to the four already listed.** The other four tell you a server *exists*. This one tells you whether it *answers right now*: every catalog entry is re-probed on a schedule with a real MCP handshake, and the verdict, latency, transport and check timestamp are stored per server.

Checkable in one command — the same data is exposed over MCP, no key, no signup:

```bash
curl -s -X POST https://mymcptools.com/api/mcp \
  -H 'Content-Type: application/json' \
  -H 'Accept: application/json, text/event-stream' \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call",
       "params":{"name":"get_server_status","arguments":{"slug":"github"}}}'
```

Returns, for the official GitHub server: `"verdict": "AUTH_REQUIRED"`, `"latency_ms": 608`, `"transport": "streamable-http"`, `"checked_at": "2026-08-15T15:20:01Z"`, and the reason in plain text — `OAuth-gated (HTTP 401) ... missing required Authorization header`. That is a probe result, not a README claim.

**Disclosures:**

- **Self-submission** — I maintain it.
- `official: false`, correctly — no vendor or steering-group affiliation.
- Description says "install-time reachability", not "uptime monitoring", because the probe cadence is scheduled rather than continuous. I'd rather undersell it in your catalog than have the line age badly.
- Free to browse and free over MCP; nothing behind the linked URL is paywalled, per your "no paid/spam listings" rule.

**Files touched:** `data/catalog.yaml` (the source of truth) plus the corresponding regenerated line in `README.md`, kept in the same name-sorted position the generator would place it (`MCP.so` → **MyMCPTools** → `Smithery`). If you'd rather regenerate yourself, drop the README commit and run `awesome-mcp readme` — the YAML record stands alone.
