### PR TITLE
Add Live Tennis API MCP server (sports)

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,10 @@ Legend: ✅ = Official / reference project · Transport: `stdio`/`sse`/`remote`
 
 - [Xquik MCP](https://docs.xquik.com/mcp/overview) `remote` — Remote X data MCP server for search, profiles, timelines, monitoring, webhooks, and confirmation-gated writes. Not affiliated with X Corp. — `x`, `twitter`, `social`, `api`
 
+### Sports
+
+- [Live Tennis API MCP](https://github.com/livetennisapi/livetennisapi-mcp) `stdio`, `remote` — Live tennis scores, fixtures, rankings, and head-to-head, with market prices and model win-probability on paid tiers. — `tennis`, `sports`, `api`, `live-scores`
+
 ### Web
 
 - [Brave Search MCP](https://github.com/brave/brave-search-mcp-server) `stdio` — Web search via Brave Search API. — `search`, `api`

--- a/data/catalog.yaml
+++ b/data/catalog.yaml
@@ -199,6 +199,16 @@ entries:
     official: false
     tags: [seo, google-ads, meta-ads, marketing, claude-code]
 
+  - id: livetennisapi-mcp
+    name: Live Tennis API MCP
+    kind: server
+    category: sports
+    url: https://github.com/livetennisapi/livetennisapi-mcp
+    description: Live tennis scores, fixtures, rankings, and head-to-head, with market prices and model win-probability on paid tiers.
+    transport: [stdio, remote]
+    official: false
+    tags: [tennis, sports, api, live-scores]
+
   - id: cursor
     name: Cursor
     kind: client


### PR DESCRIPTION
Adds the Live Tennis API MCP server to `data/catalog.yaml` (kind: server, category: sports — a new grouping, sibling to the existing NotFair/Xquik data servers) and regenerated README.md via `awesome-mcp readme`; `awesome-mcp validate` and `pytest` both pass. Open-source TypeScript, npm `livetennisapi-mcp`, stdio + hosted remote — live tennis scores, fixtures, rankings and H2H, with market prices and win-probability on paid tiers. Disclosure: I run the Live Tennis API, so this is vendor-authored — judge accordingly. Source: https://github.com/livetennisapi/livetennisapi-mcp