### PR TITLE
Add SandBase CLI to the MCP catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Legend: ✅ = Official / reference project · Transport: `stdio`/`sse`/`remote`
 ### AI
 
 - [Memory Server](https://github.com/modelcontextprotocol/servers/tree/main/src/memory) ✅ `stdio` — Persistent knowledge-graph memory across conversations. — `memory`, `graph`
+- [SandBase CLI](https://github.com/sandbaseai/cli) `stdio` — Local MCP bridge for discovering and running 2,000+ AI models from 25 supported clients. — `ai`, `models`, `cli`, `gateway`
 - [Sequential Thinking](https://github.com/modelcontextprotocol/servers/tree/main/src/sequentialthinking) ✅ `stdio` — Structured step-by-step reasoning tool for complex problems. — `reasoning`, `planning`
 
 ### Browser

--- a/data/catalog.yaml
+++ b/data/catalog.yaml
@@ -89,6 +89,16 @@ entries:
     official: false
     tags: [coding, agents, runtime]
 
+  - id: sandbase-cli
+    name: SandBase CLI
+    kind: server
+    category: ai
+    url: https://github.com/sandbaseai/cli
+    description: Local MCP bridge for discovering and running 2,000+ AI models from 25 supported clients.
+    transport: [stdio]
+    official: false
+    tags: [ai, models, cli, gateway]
+
   - id: playwright-mcp
     name: Playwright MCP
     kind: server


### PR DESCRIPTION
## Summary

Adds [SandBase CLI](https://github.com/sandbaseai/cli) to the AI server catalog.

SandBase CLI is an Apache-2.0 local MCP bridge that lets 25 supported AI clients discover and run 2,000+ AI models through six MCP tools.

## Why it belongs

- Clear MCP support in the canonical repository
- Actively maintained open-source TypeScript project
- Distinct model discovery and execution use case

## Validation

- `awesome-mcp validate` — 34 entries validated
- `pytest` — 6 passed
- `git diff --check` — passed
- README regenerated with `awesome-mcp readme`

## Disclosure

I am affiliated with SandBase.
