### PR TITLE
Add Pocket Drives to the MCP catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Legend: ✅ = Official / reference project · Transport: `stdio`/`sse`/`remote`
 - [Brave Search MCP](https://github.com/brave/brave-search-mcp-server) `stdio` — Web search via Brave Search API. — `search`, `api`
 - [BuyWhere MCP](https://github.com/BuyWhere/buywhere-mcp) `remote` — Real-time product search and price comparison across 148M+ products from Singapore, Southeast Asia, and US marketplaces via remote streamable-HTTP. — `search`, `ecommerce`, `api`
 - [Fetch Server](https://github.com/modelcontextprotocol/servers/tree/main/src/fetch) ✅ `stdio` — Fetch and convert web pages to markdown for LLM consumption. — `http`, `scraping`
+- [Pocket Drives](https://github.com/RevList/pocket-drives-mcp) `remote` — Search peer-to-peer luxury, exotic, and EV rentals from independent hosts. Booking finishes in the iOS app. Remote streamable HTTP at https://pocketdrives.ai/mcp. — `search`, `travel`, `rental`
 
 <!-- CATALOG:SERVERS:END -->
 

--- a/data/catalog.yaml
+++ b/data/catalog.yaml
@@ -358,3 +358,13 @@ entries:
     transport: [stdio]
     official: true
     tags: [debug, devtools]
+
+  - id: pocket-drives
+    name: Pocket Drives
+    kind: server
+    category: web
+    url: https://github.com/RevList/pocket-drives-mcp
+    description: Search peer-to-peer luxury, exotic, and EV rentals from independent hosts. Booking finishes in the iOS app. Remote streamable HTTP at https://pocketdrives.ai/mcp.
+    transport: [remote]
+    official: false
+    tags: [search, travel, rental]


### PR DESCRIPTION
Adds Pocket Drives to `data/catalog.yaml` (kind: server, category: web, transport: remote) and regenerates the README catalog section. It sits under MCP Servers → Web next to BuyWhere MCP.

Pocket Drives is a remote MCP for searching peer-to-peer luxury, exotic, and EV rentals from independent hosts. Booking finishes in the iOS app. Streamable HTTP at https://pocketdrives.ai/mcp. Listing repo: https://github.com/RevList/pocket-drives-mcp. Official registry: `ai.pocketdrives/pocket-drives`.

Validation on the branch: `awesome-mcp validate` (35 entries), `awesome-mcp readme`, and `pytest` (6/6) all passed.

PocketList Inc builds the platform. Hosts are independent operators (not a Pocket-owned fleet).