### PR TITLE
catalog: add Live Tennis API MCP server (data feed for real-time tennis match state)

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,10 @@ Legend: ✅ = Official / reference project · Transport: `stdio`/`sse`/`remote`
 
 - [Xquik MCP](https://docs.xquik.com/mcp/overview) `remote` — Remote X data MCP server for search, profiles, timelines, monitoring, webhooks, and confirmation-gated writes. Not affiliated with X Corp. — `x`, `twitter`, `social`, `api`
 
+### Sports
+
+- [Live Tennis API](https://github.com/livetennisapi/livetennisapi-mcp) `stdio` — Real-time tennis match state (score, server, three-valued break-point, retirement/walkover/completed) plus players, rankings, Elo, and fixtures. — `tennis`, `sports`, `real-time`, `data`
+
 ### Web
 
 - [Brave Search MCP](https://github.com/brave/brave-search-mcp-server) `stdio` — Web search via Brave Search API. — `search`, `api`

--- a/data/catalog.yaml
+++ b/data/catalog.yaml
@@ -209,6 +209,16 @@ entries:
     official: false
     tags: [seo, google-ads, meta-ads, marketing, claude-code]
 
+  - id: live-tennis-api
+    name: Live Tennis API
+    kind: server
+    category: sports
+    url: https://github.com/livetennisapi/livetennisapi-mcp
+    description: Real-time tennis match state (score, server, three-valued break-point, retirement/walkover/completed) plus players, rankings, Elo, and fixtures.
+    transport: [stdio]
+    official: false
+    tags: [tennis, sports, real-time, data, elo]
+
   - id: cursor
     name: Cursor
     kind: client


### PR DESCRIPTION
Closes the request in #26.

Adds the Live Tennis API MCP server to `data/catalog.yaml` (id `live-tennis-api`, as suggested by the maintainer) and regenerates `README.md` via `awesome-mcp readme`.

**What it is:** a TypeScript MCP server that exposes a read-only tennis DATA feed — real-time match state (score, current server, three-valued break-point flag, retirement/walkover/completed status) plus players, rankings, Elo, and fixtures. Listed on the official MCP Registry. It is a data source only, not an execution or trading tool.

**Entry**
```yaml
- id: live-tennis-api
  name: Live Tennis API
  kind: server
  category: sports
  url: https://github.com/livetennisapi/livetennisapi-mcp
  description: Real-time tennis match state (score, server, three-valued break-point, retirement/walkover/completed) plus players, rankings, Elo, and fixtures.
  transport: [stdio]
  official: false
  tags: [tennis, sports, real-time, data, elo]
```

**Free tier (no card):** live scores + match state + players (ranking + Elo) + fixtures at 30 req/min and 100 req/day; key at https://livetennisapi.com/subscribe/free . Base `https://api.livetennisapi.com/api/public/v1`, header `X-API-Key`, responses shaped `{"data":[...]}`. The live WebSocket feed and the model win-probability are paid (Ultra) tiers.

**Tooling run**
- `awesome-mcp validate` -> OK, 35 entries validated
- `awesome-mcp readme` -> README regenerated; `awesome-mcp readme --check` reports current
- `pytest` -> 6 passed

Checklist: link resolves to the canonical repo, description is factual (no marketing fluff), actively maintained, no duplicate id, not a paid/spam listing (free tier available).

Disclosure: I maintain the Live Tennis API — judge it on the merits.
