### PR TITLE
Add Worklittle Jobs MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Legend: ✅ = Official / reference project · Transport: `stdio`/`sse`/`remote`
 ### Web
 
 - [Brave Search MCP](https://github.com/brave/brave-search-mcp-server) `stdio` — Web search via Brave Search API. — `search`, `api`
-- [Worklittle Jobs](https://github.com/worklittle/jobs-mcp) `remote` — Search over 4 million jobs with visa, salary, and distance filters. Streamable HTTP at `https://mcp.worklittle.com/`. Official registry `io.github.worklittle/jobs`. — `jobs`, `search`, `remote`
+- [Worklittle Jobs](https://github.com/worklittle/jobs-mcp) `remote` — Swipe to apply for jobs in your AI app, and search over 4 million jobs with filters like visa status, distance, and salary, and connect your Worklittle account to save jobs you love.. Streamable HTTP at `https://mcp.worklittle.com/`. Official registry `io.github.worklittle/jobs`. — `jobs`, `search`, `remote`
 - [BuyWhere MCP](https://github.com/BuyWhere/buywhere-mcp) `remote` — Real-time product search and price comparison across 148M+ products from Singapore, Southeast Asia, and US marketplaces via remote streamable-HTTP. — `search`, `ecommerce`, `api`
 - [Fetch Server](https://github.com/modelcontextprotocol/servers/tree/main/src/fetch) ✅ `stdio` — Fetch and convert web pages to markdown for LLM consumption. — `http`, `scraping`
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Legend: ✅ = Official / reference project · Transport: `stdio`/`sse`/`remote`
 ### Web
 
 - [Brave Search MCP](https://github.com/brave/brave-search-mcp-server) `stdio` — Web search via Brave Search API. — `search`, `api`
-- [Worklittle Jobs](https://github.com/worklittle/jobs-mcp) `remote` — Swipe to apply for jobs in your AI app, and search over 4 million jobs with filters like visa status, distance, and salary, and connect your Worklittle account to save jobs you love.. Streamable HTTP at `https://mcp.worklittle.com/`. Official registry `io.github.worklittle/jobs`. — `jobs`, `search`, `remote`
+- [Worklittle Jobs](https://github.com/worklittle/jobs-mcp) `remote` — Swipe to apply for jobs in your AI app, and search over 4 million jobs with filters like visa status, distance, and salary, and connect your Worklittle account to save jobs you love. Streamable HTTP at `https://mcp.worklittle.com/`. Official registry `io.github.worklittle/jobs`. — `jobs`, `search`, `remote`
 - [BuyWhere MCP](https://github.com/BuyWhere/buywhere-mcp) `remote` — Real-time product search and price comparison across 148M+ products from Singapore, Southeast Asia, and US marketplaces via remote streamable-HTTP. — `search`, `ecommerce`, `api`
 - [Fetch Server](https://github.com/modelcontextprotocol/servers/tree/main/src/fetch) ✅ `stdio` — Fetch and convert web pages to markdown for LLM consumption. — `http`, `scraping`
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Legend: ✅ = Official / reference project · Transport: `stdio`/`sse`/`remote`
 ### Web
 
 - [Brave Search MCP](https://github.com/brave/brave-search-mcp-server) `stdio` — Web search via Brave Search API. — `search`, `api`
+- [Worklittle Jobs](https://github.com/worklittle/jobs-mcp) `remote` — Search over 4 million jobs with visa, salary, and distance filters. Streamable HTTP at `https://mcp.worklittle.com/`. Official registry `io.github.worklittle/jobs`. — `jobs`, `search`, `remote`
 - [BuyWhere MCP](https://github.com/BuyWhere/buywhere-mcp) `remote` — Real-time product search and price comparison across 148M+ products from Singapore, Southeast Asia, and US marketplaces via remote streamable-HTTP. — `search`, `ecommerce`, `api`
 - [Fetch Server](https://github.com/modelcontextprotocol/servers/tree/main/src/fetch) ✅ `stdio` — Fetch and convert web pages to markdown for LLM consumption. — `http`, `scraping`
 


### PR DESCRIPTION
Add Worklittle Jobs.

- Remote MCP: https://mcp.worklittle.com/
- Source: https://github.com/worklittle/jobs-mcp
- Official registry: io.github.worklittle/jobs
- Docs: https://docs.worklittle.com/mcp
- Support: support@worklittle.com

Search over 4 million jobs with visa, salary, and distance filters, swipe to apply in your AI app, and save roles to a Worklittle account.

Made with [Cursor](https://cursor.com)