### PR TITLE
Update Hephaestus entry to Agentlas OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,10 +181,10 @@ Legend: ✅ = Official / reference project · Transport: `stdio`/`sse`/`remote`
 
 ### Developer Tools
 
+- [Agentlas OS](https://github.com/agentlas-ai/Agentlas-OS) `stdio` — Local-first agent OS for portable agent and team packages over MCP. — `coding`, `agents`, `runtime`
 - [ax](https://github.com/Necmttn/ax) `stdio` — Local-first telemetry and memory graph for AI coding agents. — `coding`, `telemetry`, `local-first`
 - [Filesystem Server](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem) ✅ `stdio` — Secure local file read/write with configurable directory allowlists. — `files`, `local`
 - [GitHub MCP Server](https://github.com/github/github-mcp-server) ✅ `stdio`, `remote` — Official GitHub integration for repos, issues, PRs, and Actions. — `github`, `git`
-- [Hephaestus](https://github.com/agentlas-ai/Hephaestus) `stdio` — Local-first runtime that routes coding agents and skills over MCP. — `coding`, `agents`, `runtime`
 - [Official MCP Reference Servers](https://github.com/modelcontextprotocol/servers) ✅ `stdio` — Reference implementations maintained by the MCP steering group (filesystem, memory, fetch, git, and more). — `reference`, `anthropic`
 
 ### Marketing

--- a/data/catalog.yaml
+++ b/data/catalog.yaml
@@ -79,12 +79,12 @@ entries:
     official: false
     tags: [coding, telemetry, local-first]
 
-  - id: hephaestus
-    name: Hephaestus
+  - id: agentlas-os
+    name: Agentlas OS
     kind: server
     category: developer-tools
-    url: https://github.com/agentlas-ai/Hephaestus
-    description: Local-first runtime that routes coding agents and skills over MCP.
+    url: https://github.com/agentlas-ai/Agentlas-OS
+    description: Local-first agent OS for portable agent and team packages over MCP.
     transport: [stdio]
     official: false
     tags: [coding, agents, runtime]


### PR DESCRIPTION
## Summary

Updates the existing Hephaestus catalog record and generated README entry to the current Agentlas OS name, canonical repository, and MCP-focused description.

This also records the already-listed Worklittle Jobs README row in data/catalog.yaml so the repository generator remains lossless; no new Worklittle README listing is introduced.

## Verification

- awesome-mcp validate: passed (37 entries)
- pytest: 6/6 passed
- awesome-mcp readme: generated a clean synchronized README
- git diff --check: passed

Disclosure: I am submitting the Agentlas update on behalf of the Agentlas project.