### PR TITLE
feat: add BulkPublish MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,10 @@ Legend: ✅ = Official / reference project · Transport: `stdio`/`sse`/`remote`
 
 - [Xquik MCP](https://docs.xquik.com/mcp/overview) `remote` — Remote X data MCP server for search, profiles, timelines, monitoring, webhooks, and confirmation-gated writes. Not affiliated with X Corp. — `x`, `twitter`, `social`, `api`
 
+### Social Media
+
+- [BulkPublish](https://github.com/azeemkafridi/bulkpublish-api) `remote` — Approval-first social content adaptation, scheduling, and publishing through a remote MCP server and API. — `social-media`, `marketing`, `publishing`, `scheduling`
+
 ### Sports
 
 - [Live Tennis API](https://github.com/livetennisapi/livetennisapi-mcp) `stdio` — Real-time tennis match state (score, server, three-valued break-point, retirement/walkover/completed) plus players, rankings, Elo, and fixtures. — `tennis`, `sports`, `real-time`, `data`

--- a/data/catalog.yaml
+++ b/data/catalog.yaml
@@ -209,7 +209,7 @@ entries:
     official: false
     tags: [seo, google-ads, meta-ads, marketing, claude-code]
 
-- id: posteverywhere
+  - id: posteverywhere
     name: PostEverywhere
     kind: server
     category: productivity
@@ -388,3 +388,13 @@ entries:
     transport: [remote]
     official: false
     tags: [search, travel, rental]
+
+  - id: bulkpublish
+    name: BulkPublish
+    kind: server
+    category: social-media
+    url: https://github.com/azeemkafridi/bulkpublish-api
+    description: Approval-first social content adaptation, scheduling, and publishing through a remote MCP server and API.
+    transport: [remote]
+    official: false
+    tags: [social-media, marketing, publishing, scheduling]


### PR DESCRIPTION
## Summary\n- add BulkPublish to the MCP server catalog\n- document its remote transport and social-media/marketing use case\n- regenerate the README\n- repair a pre-existing indentation error in the catalog so validation can run\n\nValidation: catalog validation, README generation, and git diff check passed. No credentials are included.