### PR TITLE
Add Agent QA and restore catalog loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@
   <a href="https://github.com/Albertchamberlain/Awesome-MCP"><img alt="Awesome" src="https://cdn.jsdelivr.net/gh/sindresorhus/awesome@main/media/badge.svg"></a>
   <a href="https://pypi.org/project/awesome-mcp/"><img alt="Python" src="https://img.shields.io/badge/python-3.10%2B-3776AB?logo=python&logoColor=white"></a>
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-MIT-4c1?logo=open-source-initiative&logoColor=white"></a>
-  <img alt="Catalog" src="https://img.shields.io/badge/catalog-27%20entries-7c3aed">
-  <img alt="Updated" src="https://img.shields.io/badge/updated-2026--06--18-059669">
+  <img alt="Catalog" src="https://img.shields.io/badge/catalog-38%20entries-7c3aed">
+  <img alt="Updated" src="https://img.shields.io/badge/updated-2026--09--05-059669">
 </p>
 
 <br>
@@ -167,6 +167,7 @@ Legend: ✅ = Official / reference project · Transport: `stdio`/`sse`/`remote`
 
 ### Browser
 
+- [Agent QA](https://github.com/vostride/agent-qa) `stdio` — MCP tools to author, validate, run, and inspect natural-language web, Android, and iOS tests; source-available under FSL-1.1-ALv2. — `testing`, `automation`, `web`, `mobile`
 - [Playwright MCP](https://github.com/microsoft/playwright-mcp) `stdio` — Browser automation via Playwright — navigate, click, screenshot, extract content. — `browser`, `automation`, `microsoft`
 - [Puppeteer Server](https://github.com/modelcontextprotocol/servers/tree/main/src/puppeteer) ✅ `stdio` — Headless Chrome automation for scraping and interaction. — `browser`, `chrome`
 

--- a/README.template.md
+++ b/README.template.md
@@ -19,8 +19,8 @@
   <a href="https://github.com/Albertchamberlain/Awesome-MCP"><img alt="Awesome" src="https://cdn.jsdelivr.net/gh/sindresorhus/awesome@main/media/badge.svg"></a>
   <a href="https://pypi.org/project/awesome-mcp/"><img alt="Python" src="https://img.shields.io/badge/python-3.10%2B-3776AB?logo=python&logoColor=white"></a>
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-MIT-4c1?logo=open-source-initiative&logoColor=white"></a>
-  <img alt="Catalog" src="https://img.shields.io/badge/catalog-27%20entries-7c3aed">
-  <img alt="Updated" src="https://img.shields.io/badge/updated-2026--06--18-059669">
+  <img alt="Catalog" src="https://img.shields.io/badge/catalog-38%20entries-7c3aed">
+  <img alt="Updated" src="https://img.shields.io/badge/updated-2026--09--05-059669">
 </p>
 
 <br>

--- a/data/catalog.yaml
+++ b/data/catalog.yaml
@@ -1,7 +1,7 @@
 # Awesome-MCP catalog — edit this file and run: awesome-mcp readme
 meta:
   version: 1
-  updated: "2026-07-03"
+  updated: "2026-09-05"
   description: Curated Model Context Protocol servers, clients, and registries
 
 categories:
@@ -109,6 +109,16 @@ entries:
     official: false
     tags: [browser, automation, microsoft]
 
+  - id: agent-qa
+    name: Agent QA
+    kind: server
+    category: browser
+    url: https://github.com/vostride/agent-qa
+    description: MCP tools to author, validate, run, and inspect natural-language web, Android, and iOS tests; source-available under FSL-1.1-ALv2.
+    transport: [stdio]
+    official: false
+    tags: [testing, automation, web, mobile, android, ios, typescript]
+
   - id: sqlite
     name: SQLite Server
     kind: server
@@ -209,7 +219,7 @@ entries:
     official: false
     tags: [seo, google-ads, meta-ads, marketing, claude-code]
 
-- id: posteverywhere
+  - id: posteverywhere
     name: PostEverywhere
     kind: server
     category: productivity

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = { text = "MIT" }
 authors = [{ name = "Albertchamberlain" }]
 keywords = ["mcp", "model-context-protocol", "awesome-list", "ai"]
 dependencies = [
-    "mcp>=1.6.0",
+    "mcp>=1.6.0,<2",
     "pyyaml>=6.0.2",
     "typer>=0.15.0",
     "rich>=13.9.0",


### PR DESCRIPTION
Add Agent QA as a stdio server in the browser category, making its natural-language application-testing tools discoverable through the README, CLI, and MCP meta-server. Update the catalog date and the README template's count/date badges to match all 38 entries.

Two existing problems prevented that discovery path from working on a fresh install:

- The `posteverywhere` item lacked two leading spaces, so the YAML could not parse. Correcting its indentation preserves every existing entry and makes all six tests pass; all six failed on the original YAML.
- The unbounded `mcp>=1.6.0` dependency selected MCP 2.1.1, whose removed `mcp.server.fastmcp` import prevented the meta-server from starting. Constrain the existing v1 implementation to `mcp>=1.6.0,<2`; it starts successfully with MCP 1.29.1.

Validation on Python 3.14.5:

- `awesome-mcp validate`: 38 valid entries; all 37 prior entries preserved.
- `awesome-mcp readme` and `awesome-mcp readme --check`: generated README is current.
- `pytest -q`: 6 passed.
- CLI search returns `agent-qa` with its canonical URL and FSL description.
- A real stdio MCP client successfully calls `get_catalog_entry` and `search_catalog` to discover Agent QA by name and by Android/iOS terms.
- `git diff --check` and all five added/supporting URLs pass.

Agent QA is [source-available under FSL-1.1-ALv2](https://github.com/vostride/agent-qa/blob/main/LICENSE.md). There is no software fee for permitted use; configured model, browser, and device providers have their own costs.

References: [project](https://github.com/vostride/agent-qa), [documentation](https://vostride.com/docs/agent-qa), and [MCP implementation](https://github.com/vostride/agent-qa/tree/main/packages/mcp).

The published `@vostride/agent-qa-mcp@0.1.21` package was installed in a temporary directory and checked with the official TypeScript MCP SDK over stdio. Initialization, discovery of 33 tools, schema lookup, ID generation/validation, and rejection of an invalid test definition passed. This check used no dashboard, model, browser, or device-provider calls; it does not attest to an end-to-end application test run.

Affiliation: this is a Vostride / Agent QA project submission, prepared with AI assistance.
