### PR TITLE
Add FLUJO web client to catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Legend: ✅ = Official / reference project · Transport: `stdio`/`sse`/`remote`
 
 ### Web
 
+- [FLUJO](https://github.com/mario-andreschak/FLUJO) `stdio`, `sse`, `remote` — Local-first visual AI agent builder with MCP server management, tool inspection, multi-model chat, and workflow debugging. — `self-hosted`, `web`, `multi-model`, `workflows`
 - [LibreChat](https://github.com/danny-avila/LibreChat) `stdio`, `sse` — Self-hosted ChatGPT-style UI with MCP plugin support. — `self-hosted`, `web`
 
 <!-- CATALOG:CLIENTS:END -->

--- a/data/catalog.yaml
+++ b/data/catalog.yaml
@@ -209,7 +209,7 @@ entries:
     official: false
     tags: [seo, google-ads, meta-ads, marketing, claude-code]
 
-- id: posteverywhere
+  - id: posteverywhere
     name: PostEverywhere
     kind: server
     category: productivity
@@ -288,6 +288,16 @@ entries:
     transport: [stdio, sse]
     official: false
     tags: [self-hosted, web]
+
+  - id: flujo
+    name: FLUJO
+    kind: client
+    category: web
+    url: https://github.com/mario-andreschak/FLUJO
+    description: Local-first visual AI agent builder with MCP server management, tool inspection, multi-model chat, and workflow debugging.
+    transport: [stdio, sse, remote]
+    official: false
+    tags: [self-hosted, web, multi-model, workflows]
 
   - id: smithery
     name: Smithery


### PR DESCRIPTION
Adds FLUJO to the Web client catalog and generated README. FLUJO is an MIT-licensed, local-first visual AI agent builder with MCP server management, tool inspection, multi-model chat, and workflow debugging. Its [client transport source](https://github.com/mario-andreschak/FLUJO/blob/main/src/backend/services/mcp/connection.ts) implements stdio, SSE, and Streamable HTTP (represented by the existing `remote` catalog tag).

The existing `posteverywhere` entry's `id` line was missing its two-space indentation, which caused YAML parsing to fail before this addition. This also fixes that single indentation error so the catalog can validate and the README can regenerate.

Validation requested by CONTRIBUTING.md:
- `awesome-mcp validate` — 38 entries validated.
- `awesome-mcp readme` — regenerated README.
- `pytest -q` — 6 passed.
- `awesome-mcp readme --check` — current.
- `git diff --check` — passed.

Checked the catalog and prior FLUJO submissions for duplicates; project details are documented in the [README](https://github.com/mario-andreschak/FLUJO#readme).