### PR TITLE
Add ReadyAgents stdio MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Legend: ✅ = Official / reference project · Transport: `stdio`/`sse`/`remote`
 - [Filesystem Server](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem) ✅ `stdio` — Secure local file read/write with configurable directory allowlists. — `files`, `local`
 - [GitHub MCP Server](https://github.com/github/github-mcp-server) ✅ `stdio`, `remote` — Official GitHub integration for repos, issues, PRs, and Actions. — `github`, `git`
 - [Official MCP Reference Servers](https://github.com/modelcontextprotocol/servers) ✅ `stdio` — Reference implementations maintained by the MCP steering group (filesystem, memory, fetch, git, and more). — `reference`, `anthropic`
+- [ReadyAgents](https://github.com/readyagents/readyagents-core) `stdio` — ReadyAgents is a free, self-hosted Apache-2.0 local one-shot agent workflow engine plus MCP toolkit: clone it, bring your own keys; always-on packs are waitlisted and not for sale. — `python`, `workflow`, `local`, `byok`
 
 ### Marketing
 

--- a/data/catalog.yaml
+++ b/data/catalog.yaml
@@ -394,7 +394,7 @@ entries:
     kind: server
     category: developer-tools
     url: https://github.com/readyagents/readyagents-core
-    description: ReadyAgents is a free, self-hosted Apache-2.0 local one-shot agent workflow engine plus MCP toolkit: clone it, bring your own keys; always-on packs are waitlisted and not for sale.
+    description: "ReadyAgents is a free, self-hosted Apache-2.0 local one-shot agent workflow engine plus MCP toolkit: clone it, bring your own keys; always-on packs are waitlisted and not for sale."
     transport: [stdio]
     official: false
     tags: [python, workflow, local, byok]

--- a/data/catalog.yaml
+++ b/data/catalog.yaml
@@ -1,7 +1,7 @@
 # Awesome-MCP catalog — edit this file and run: awesome-mcp readme
 meta:
   version: 1
-  updated: "2026-07-03"
+  updated: "2026-09-06"
   description: Curated Model Context Protocol servers, clients, and registries
 
 categories:
@@ -209,7 +209,7 @@ entries:
     official: false
     tags: [seo, google-ads, meta-ads, marketing, claude-code]
 
-- id: posteverywhere
+  - id: posteverywhere
     name: PostEverywhere
     kind: server
     category: productivity
@@ -388,3 +388,13 @@ entries:
     transport: [remote]
     official: false
     tags: [search, travel, rental]
+
+  - id: readyagents-core
+    name: ReadyAgents
+    kind: server
+    category: developer-tools
+    url: https://github.com/readyagents/readyagents-core
+    description: ReadyAgents is a free, self-hosted Apache-2.0 local one-shot agent workflow engine plus MCP toolkit: clone it, bring your own keys; always-on packs are waitlisted and not for sale.
+    transport: [stdio]
+    official: false
+    tags: [python, workflow, local, byok]


### PR DESCRIPTION
## Summary
- Adds `readyagents-core` to `data/catalog.yaml` as a local stdio MCP server (`readyagents mcp serve`).
- Restores two missing leading spaces on the existing `posteverywhere` list item so the catalog loads (same class of indent break noted in open issues).

## Why it belongs
ReadyAgents is a free Apache-2.0 local one-shot agent workflow engine plus optional stdio MCP toolkit (BYOK). Always-on packs are waitlisted and not for sale.

Validation: `awesome-mcp validate`, `awesome-mcp readme`, and `pytest` passed.