### PR TITLE
Update ReadyAgents link to readyagentsdev/readyagents-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Legend: ✅ = Official / reference project · Transport: `stdio`/`sse`/`remote`
 - [Filesystem Server](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem) ✅ `stdio` — Secure local file read/write with configurable directory allowlists. — `files`, `local`
 - [GitHub MCP Server](https://github.com/github/github-mcp-server) ✅ `stdio`, `remote` — Official GitHub integration for repos, issues, PRs, and Actions. — `github`, `git`
 - [Official MCP Reference Servers](https://github.com/modelcontextprotocol/servers) ✅ `stdio` — Reference implementations maintained by the MCP steering group (filesystem, memory, fetch, git, and more). — `reference`, `anthropic`
-- [ReadyAgents](https://github.com/readyagents/readyagents-core) `stdio` — ReadyAgents is a free, self-hosted Apache-2.0 local one-shot agent workflow engine plus MCP toolkit: clone it, bring your own keys; always-on packs are waitlisted and not for sale. — `python`, `workflow`, `local`, `byok`
+- [ReadyAgents](https://github.com/readyagentsdev/readyagents-core) `stdio` — ReadyAgents is a free, self-hosted Apache-2.0 local one-shot agent workflow engine plus MCP toolkit: git clone + pip install -e . (or see https://readyagents.dev); bring your own keys; always-on packs are waitlisted and not for sale. — `python`, `workflow`, `local`, `byok`
 
 ### Marketing
 

--- a/data/catalog.yaml
+++ b/data/catalog.yaml
@@ -419,17 +419,16 @@ entries:
     official: false
     tags: [search, travel, rental]
 
-<<<<<<< HEAD
   - id: readyagents-core
     name: ReadyAgents
     kind: server
     category: developer-tools
-    url: https://github.com/readyagents/readyagents-core
-    description: "ReadyAgents is a free, self-hosted Apache-2.0 local one-shot agent workflow engine plus MCP toolkit: clone it, bring your own keys; always-on packs are waitlisted and not for sale."
+    url: https://github.com/readyagentsdev/readyagents-core
+    description: "ReadyAgents is a free, self-hosted Apache-2.0 local one-shot agent workflow engine plus MCP toolkit: git clone + pip install -e . (or see https://readyagents.dev); bring your own keys; always-on packs are waitlisted and not for sale."
     transport: [stdio]
     official: false
     tags: [python, workflow, local, byok]
-=======
+
   - id: bulkpublish
     name: BulkPublish
     kind: server
@@ -439,4 +438,3 @@ entries:
     transport: [remote]
     official: false
     tags: [social-media, marketing, publishing, scheduling]
->>>>>>> pr38


### PR DESCRIPTION
## Summary
- Updates the existing ReadyAgents entry to https://github.com/readyagentsdev/readyagents-core in `data/catalog.yaml` and `README.md`
- Clarifies install via `git clone` + `pip install -e .` (or see https://readyagents.dev)
- Resolves leftover merge-conflict markers in `data/catalog.yaml` so both ReadyAgents and BulkPublish entries remain

## Notes
- Follow-up to merged PR #44; does not re-add a duplicate entry.